### PR TITLE
Change font size to 12pt

### DIFF
--- a/ThesisTemplate.tex
+++ b/ThesisTemplate.tex
@@ -15,7 +15,7 @@
 % --------------------------------------------------------------------------
 
 % This includes the magical class file with the formatting. ** DO NOT REPLACE THIS. Everything WILL break. **
-\documentclass[12pt]{UIdahoMastersThesis}
+\documentclass{UIdahoMastersThesis}
 
 % --------------------------------------------------------------------------
 % Packages (the class file already imports several. Importing twice usually doesn't hurt, just keep in mind for debugging)

--- a/UIdahoMastersThesis.cls
+++ b/UIdahoMastersThesis.cls
@@ -8,7 +8,7 @@
 
 
 % Sets up the class
-\LoadClass[oneside]{book}
+\LoadClass[oneside,12pt]{book}
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{UIdahoMastersThesis}[2017/04/03 University of Idaho Masters Thesis]
 


### PR DESCRIPTION
Thanks for the excellent template! I noticed my font was quite small in comparison to a few other people typing up their thesis in Word. Then I realized it was still using the default 10pt LaTeX font! 

It was confusing that the template has 12pt specified in it but it was not being passed to anything. I specified the 12pt default font in the inheretence from the `book` class. 