### PR TITLE
ThesisTemplate.tex: Fix subsection numbering bug

### DIFF
--- a/ThesisTemplate.tex
+++ b/ThesisTemplate.tex
@@ -96,7 +96,7 @@ pdfprintscaling={AppDefault}]
     \titlespacing{\section}{0pt}{0pt}{10pt}
 	%\titlespacing*{\section}{0pt}{-50pt}{40pt}
 
-\titleformat{\subsection}[hang]{\scshape\large}{\thesection}{1ex}{}
+\titleformat{\subsection}[hang]{\scshape\large}{\thesubsection}{1ex}{}
     \titlespacing{\subsection}{0pt}{0pt}{10pt}
 	%\titlespacing*{\subsection}{0pt}{-50pt}{40pt}
 


### PR DESCRIPTION
Currently subsections are not numbered properly. They get the section number instead of the subsection number. 

E.g.
```
1.5 This is a section
  1.5 This is a subsection
```

The titlesec package format is defined incorrectly for subsections. This should fix that issue.

Now:
```
1.5 This is a section
  1.5.1 This is a subsection
```